### PR TITLE
Fix #200041 (Hotfix)

### DIFF
--- a/arnak.js
+++ b/arnak.js
@@ -2319,6 +2319,7 @@ function (dojo, declare) {
 						this.addActionButton("button_buy_plane", coinIcon + coinIcon + arrow + planeIcon, 'buyPlane');
 						break;
 					case 'mayTravel':
+					case 'mustTravel':
 						this.addActionButton("button_cancel_travel", _("I don't want to travel"), 'hardCancelTravel');
 						break;
 					case "idolExile": case "researchExile": case "assExile":  case "exileForCard": case "mayExile": case "hairpinExile":

--- a/modules/card_effects.php
+++ b/modules/card_effects.php
@@ -379,13 +379,13 @@ class CardEffects extends APP_GameClass {
 			case 11:
 				$game->setGameStateValue("discount-compass", 3);
 				$game->setGameStateValue("discount-plane", 1);
-				$game->gamestate->nextState("mustTravel");
+				$game->gamestate->nextState("mayTravel");
 				// reset dis
 				break;
 			case 12:
 				$game->setGameStateValue("discount-compass", 2);
 				$game->setGameStateValue("discount-plane", 1);
-				$game->gamestate->nextState("mustTravel");
+				$game->gamestate->nextState("mayTravel");
 				// reset dis
 				break;
 				

--- a/states.inc.php
+++ b/states.inc.php
@@ -106,7 +106,7 @@ $machinestates = array(
 			"description" => clienttranslate('${actplayer} must travel to a site'),
 			"descriptionmyturn" => clienttranslate('${you} must travel to a site'),
 			"possibleactions" => array( "playCard", "digSite", "discoverSite", "useAssistant", "useIdol", "useGuardPower", "pass", "undo"),
-			"transitions" => array("siteEffect" => SITE_EFFECT, "discover" => EVAL_IDOL),
+			"transitions" => array("siteEffect" => SITE_EFFECT, "discover" => EVAL_IDOL, "cancel" => AFTER_MAIN),
 	),
 	MAY_TRAVEL => array(
 			"name" => "mayTravel",


### PR DESCRIPTION
When using Aeroplane(11) or Hot Air Balloon(12), if there is no Archeologist left on the player's board, only the "undo action" can be done. And if and undoable action is made (draw a card for ex), the game is stuck.

We need a "I dont want to travel" button, which is present for other traveling effects cards.

Strangely, those 2 cards are in the MUST_TRAVEL state, but i can see no reason. Because the MAY_TRAVEL state is identical (except the cancel feature)

First give a way to get out of MUST_TRAVEL state, allowing to perform a "cancel" This is a hotfix, some current games will be impacted, so we cannot remove the MUST_TRAVEL state, this may be done later